### PR TITLE
#8 dicomviewr will try to load benchmarks json files from the nextcloud root folder. 404 error for /benchmarks/

### DIFF
--- a/extensions/cornerstone/src/init.tsx
+++ b/extensions/cornerstone/src/init.tsx
@@ -58,7 +58,7 @@ export default async function init({
   // DO NOT CHANGE THE ORDER
 
   // Set configurations to retrieve benchmark data from the local file
-  const benchmarkPublicFileURL = '/benchmarks/';
+  const benchmarkPublicFileURL = './benchmarks/';
   const config = cornerstone.getConfiguration();
   const newConfig = {
     gpuTier: config.gpuTier,


### PR DESCRIPTION
This PR fixes #8 